### PR TITLE
pool party data read

### DIFF
--- a/abis/PoolParty.json
+++ b/abis/PoolParty.json
@@ -1,0 +1,338 @@
+[
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_jellyToken",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_usdToken",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_usdToJellyRatio",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_jellySwapVault",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_jellySwapPoolId",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "_owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_pendingOwner",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "Ownable__CallerIsNotOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "Ownable__CannotSetOwnerToZeroAddress",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "Ownable__CannotTransferToSelf",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "Ownable__MustBeProposedOwner",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PoolParty__CannotBuy",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PoolParty__NoValueSent",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "usdAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "jellyAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "buyer",
+          "type": "address"
+        }
+      ],
+      "name": "BuyWithUsd",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EndBuyingPeriod",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "usdToJellyRatio",
+          "type": "uint256"
+        }
+      ],
+      "name": "NativeToJellyRatioSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferCanceled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferRequested",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "acceptOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "buyWithUsd",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "cancelOwnershipTransfer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "endBuyingPeriod",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getPendingOwner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "i_jellyToken",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isOver",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "jellySwapPoolId",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "jellySwapVault",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_usdToJellyRatio",
+          "type": "uint256"
+        }
+      ],
+      "name": "setUSDToJellyRatio",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "usdToJellyRatio",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "usdToken",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1728,6 +1728,28 @@ dataSources:
         - event: VestingStakingClaimed(uint256,address)
           handler: handleVestingStakingClaimed
     {{/if}}
+  {{#if PoolParty}}
+  - kind: ethereum/contract
+    name: PoolParty
+    network: {{network}}
+    source:
+      address: '{{PoolParty.address}}'
+      abi: PoolParty
+      startBlock: {{PoolParty.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolParty.ts
+      entities:
+        - PoolPartyBurner
+      abis:
+        - name: PoolParty
+          file: ./abis/PoolParty.json
+      eventHandlers:
+        - event: BuyWithUsd(uint256,uint256,address)
+          handler: handleBuyWithUsd
+    {{/if}}
 templates:
   - kind: ethereum/contract
     name: WeightedPool
@@ -2453,3 +2475,21 @@ templates:
       abis:
         - name: StakingRewardDistribution
           file: ./abis/StakingRewardDistribution.json
+  - kind: ethereum/contract
+    name: PoolParty
+    network: {{network}}
+    source:
+      abi: PoolParty
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolParty.ts
+      entities:
+        - PoolPartyBurners
+      abis:
+        - name: PoolParty
+          file: ./abis/PoolParty.json
+      eventHandlers:
+        - event: BuyWithUsd(uint256,uint256,address)
+          handler: handleBuyWithUsd        

--- a/networks.yaml
+++ b/networks.yaml
@@ -719,6 +719,9 @@ sepolia:
   RewardVesting:
     address: "0x407F9C0a0fCEE48ae0a86C74dF62093b2d9B9d83"
     startBlock: 5531707
+  PoolParty: 
+    address: "0x758b9Ce992C866821767854C2a4b0B28E3130110"
+    startBlock: 5633216
 polygon-zkevm:
   network: polygon-zkevm
   EventEmitter:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ devDependencies:
     specifier: 0.52.0
     version: 0.52.0(@types/node@16.18.52)(node-fetch@2.7.0)(typescript@4.9.5)
   '@graphprotocol/graph-ts':
-    specifier: 0.31.0
+    specifier: ^0.31.0
     version: 0.31.0
   '@types/jest':
     specifier: ^26.0.20

--- a/schema.graphql
+++ b/schema.graphql
@@ -524,3 +524,10 @@ type VestingStakingClaimed @entity {
   beneficiary: Bytes!
   amount: BigInt!
 }
+
+type PoolPartyBurner @entity {
+  id: ID!
+  usdAmount: BigInt!
+  beneficiary: Bytes!
+  jellyAmount: BigInt!
+}

--- a/src/mappings/poolParty.ts
+++ b/src/mappings/poolParty.ts
@@ -1,0 +1,20 @@
+import { PoolPartyBurner } from '../types/schema';
+import { BuyWithUsd } from '../types/templates/PoolParty/PoolParty';
+
+export function handleBuyWithUsd(event: BuyWithUsd): void {
+  let userId = event.params.buyer;
+
+  let poolPartyBurner = PoolPartyBurner.load(userId.toHexString());
+  if (poolPartyBurner == null) {
+    let newPoolPartyBurner = new PoolPartyBurner(userId.toHexString());
+    newPoolPartyBurner.beneficiary = userId;
+    newPoolPartyBurner.usdAmount = event.params.usdAmount;
+    newPoolPartyBurner.jellyAmount = event.params.jellyAmount;
+
+    newPoolPartyBurner.save();
+    return;
+  }
+  poolPartyBurner.usdAmount = poolPartyBurner.usdAmount.plus(event.params.usdAmount);
+  poolPartyBurner.jellyAmount = poolPartyBurner.jellyAmount.plus(event.params.jellyAmount);
+  poolPartyBurner.save();
+}


### PR DESCRIPTION
# Description

Please include a summary of the change and if relevant which issue is fixed. Please also include relevant motivation and context.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have [checked](https://balancer.github.io/balancer-subgraph-v2/status.html) that all beta deployments have synced
- [ ] I have [checked](https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-prune-v2-beta/graphql?query=%0A%7B%0A++balancers%28block%3A%7Bnumber%3A1%7D%29%7B%0A++++id%0A++%7D%0A%7D) that the earliest block in the polygon pruned deployment is [block, date/time](https://polygonscan.com/block/block)
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
